### PR TITLE
Add charm release pipeline workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: >
         Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
-        sure you are using the latest version of the charm. If not, please switch to the lastest version of this charm
+        sure you are using the latest version of the charm. If not, please switch to the latest version of this charm
         before posting your report to make sure it's not already solved.
   - type: textarea
     id: bug-description

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,6 @@ jobs:
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.2.0
         with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Release to latest/edge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci-tests:
+    uses: ./.github/workflows/ci.yaml
+
+  release-to-charmhub:
+    name: Release to CharmHub
+    needs:
+      - ci-tests
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@2.2.0
+        id: channel
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@2.2.0
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "${{ steps.channel.outputs.name }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[tool.codespell]
-skip = "./build,./lib,./venv,./icon.svg"
-
 # Testing tools configuration
 [tool.coverage.run]
 branch = true
@@ -25,6 +22,10 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+
+# Spell checking tools configuration
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.vscode,.coverage"
 
 # Formatting tools configuration
 [tool.black]

--- a/src/charm.py
+++ b/src/charm.py
@@ -192,7 +192,7 @@ class SlurmdCharm(CharmBase):
 
     def ensure_slurmd_starts(self, max_attemps=10) -> bool:
         """Ensure slurmd is up and running."""
-        logger.debug("## Stoping slurmd")
+        logger.debug("## Stopping slurmd")
         self._slurm_manager.slurm_systemctl("stop")
 
         for i in range(max_attemps):
@@ -243,7 +243,7 @@ class SlurmdCharm(CharmBase):
 
     @property
     def etcd_use_tls(self) -> bool:
-        """Return wether TLS certificates are available."""
+        """Return whether TLS certificates are available."""
         return bool(self.etcd_tls_cert)
 
     @property
@@ -393,12 +393,12 @@ class SlurmdCharm(CharmBase):
             self._slurmd_peer.partition_name = name
 
     def _write_munge_key_and_restart_munge(self):
-        logger.debug("#### slurmd charm - writting munge key")
+        logger.debug("#### slurmd charm - writing munge key")
 
         self._slurm_manager.configure_munge_key(self._slurmd.get_stored_munge_key())
 
         if self._slurm_manager.restart_munged():
-            logger.debug("## Munge restarted succesfully")
+            logger.debug("## Munge restarted successfully")
         else:
             logger.error("## Unable to restart munge")
 
@@ -460,7 +460,7 @@ class SlurmdCharm(CharmBase):
         """Install infiniband."""
         logger.debug("#### Installing Infiniband")
         self._slurm_manager.infiniband.install()
-        event.set_results({"installation": "Successfull. Please reboot node."})
+        event.set_results({"installation": "Successful. Please reboot node."})
         self.unit.status = BlockedStatus("Need reboot for Infiniband")
 
     def uninstall_infiniband(self, event):
@@ -480,7 +480,7 @@ class SlurmdCharm(CharmBase):
 
     def stop_infiniband(self, event):
         """Stop Infiniband systemd service."""
-        logger.debug("#### Stoping Infiniband service")
+        logger.debug("#### Stopping Infiniband service")
         self._slurm_manager.infiniband.stop()
 
     def is_active_infiniband(self, event):
@@ -510,7 +510,7 @@ class SlurmdCharm(CharmBase):
         """Install nvidia drivers."""
         logger.debug("#### Installing nvidia drivers: %s", self._slurm_manager.nvidia.package)
         self._slurm_manager.nvidia.install()
-        event.set_results({"installation": "Successfull. Please reboot node."})
+        event.set_results({"installation": "Successful. Please reboot node."})
         self.unit.status = BlockedStatus("Need reboot for nvidia")
 
     def singularity_install(self, event):
@@ -525,7 +525,7 @@ class SlurmdCharm(CharmBase):
                 resource_path = self.model.resources.fetch(resource_name)
                 logger.debug(f"#### Found singularity resource: {resource_path}")
                 self._slurm_manager.singularity.install(resource_path)
-                event.set_results({"installation": "Successfull."})
+                event.set_results({"installation": "Successful."})
             except ModelError as e:
                 logger.error(f"## Missing singularity resource - {e}")
                 event.fail(message=f"Error installing Singularity: {e.output}")
@@ -535,7 +535,7 @@ class SlurmdCharm(CharmBase):
         self._slurm_manager.mpi.install()
 
         if self._slurm_manager.mpi.installed:
-            event.set_results({'installation': 'Successfull.'})
+            event.set_results({"installation": "Successful."})
         else:
             event.fail(message="Error installing mpich. Check the logs.")
 
@@ -551,7 +551,7 @@ class SlurmdCharm(CharmBase):
             # If the relation with slurmctld exists then set our
             # partition info on the application relation data.
             # This handler shouldn't fire if the relation isn't made,
-            # but add this extra check here just incase.
+            # but add this extra check here just in case.
             if self._slurmd.is_joined:
                 partition = self._assemble_partition()
                 if partition:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,16 +17,17 @@
 
 import pathlib
 
+from helpers import ETCD, NHC, VERSION
 from pytest import fixture
 from pytest_operator.plugin import OpsTest
-
-from helpers import ETCD, NHC, VERSION
 
 
 @fixture(scope="module")
 async def slurmd_charm(ops_test: OpsTest):
+    """Build slurmd charm to use for integration tests."""
     charm = await ops_test.build_charm(".")
     return charm
+
 
 def pytest_sessionfinish(session, exitstatus) -> None:
     """Clean up repository after test session has completed."""

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -19,7 +19,6 @@ import logging
 import pathlib
 import shlex
 import subprocess
-
 from typing import Dict
 from urllib import request
 
@@ -45,6 +44,7 @@ def get_slurmctld_res() -> Dict[str, pathlib.Path]:
         request.urlretrieve(ETCD_URL, etcd)
 
     return {"etcd": etcd}
+
 
 def get_slurmd_res() -> Dict[str, pathlib.Path]:
     """Get slurmd resources needed for charm deployment."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,18 +16,13 @@
 """Test slurmd charm against other SLURM charms in the latest/edge channel."""
 
 import asyncio
+
 import pytest
-
 from helpers import (
-    get_slurmd_res,
     get_slurmctld_res,
+    get_slurmd_res,
 )
-
-from pathlib import Path
 from pytest_operator.plugin import OpsTest
-from tenacity import retry
-from tenacity.stop import stop_after_attempt
-from tenacity.wait import wait_exponential as wexp
 
 SERIES = ["focal"]
 SLURMD = "slurmd"
@@ -85,11 +80,11 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str, slurmd_charm):
 
     # Build and Deploy Slurmd
     await ops_test.model.deploy(
-            str(await slurmd_charm),
-            application_name=SLURMD,
-            num_units=1,
-            resources=res_slurmd,
-            series=series,
+        str(await slurmd_charm),
+        application_name=SLURMD,
+        num_units=1,
+        resources=res_slurmd,
+        series=series,
     )
 
     # Attach NHC resource to the slurmd controller

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -24,7 +24,10 @@ from ops.testing import Harness
 
 
 class TestCharm(unittest.TestCase):
+    """Unit test slurmd charm."""
+
     def setUp(self) -> None:
+        """Set up unit test."""
         self.harness = Harness(SlurmdCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()


### PR DESCRIPTION
## Description

Provides the charm publishing pipeline workflow for publishing charms.

## How was the code tested?

Won't work till it reaches Omnivector repo with a valid secret named `CHARMHUB_TOKEN`. Could also have a canonical repository secret to test publishing, however, I do not think we want to be publishing Canonical and Omnivector versions of the charms.

## Related issues and/or tasks

See related Projects

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [x] All requested changes and/or review comments have been resolved.
